### PR TITLE
Update API to override and ignore files

### DIFF
--- a/.github/workflows/lint.js.yml
+++ b/.github/workflows/lint.js.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  lint-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/lint.js.yml
+++ b/.github/workflows/lint.js.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 15.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 15.x
+    - run: yarn
+    - run: yarn lint

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -26,4 +26,3 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: yarn
     - run: yarn test
-    - run: yarn lint

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -10,15 +10,14 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  test:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x, 15.x]
+        platform: [macos-latest, ubuntu-latest, windows-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
+    runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.js.yml
+++ b/.github/workflows/test.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  jest-test:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x, 15.x]

--- a/lib/eval.js
+++ b/lib/eval.js
@@ -40,7 +40,6 @@ module.exports = (filepath, newpath, variables) => {
       try {
         const eval_content = ejs.render(content.toString(), variables);
 
-        console.log(newpath);
         fs.writeFileSync(newpath, eval_content);
       } catch (err) {
         reject(err);

--- a/lib/eval.js
+++ b/lib/eval.js
@@ -21,11 +21,11 @@ const path = require("path");
  * @return {Promise<void>}
  */
 module.exports = (filepath, newpath, variables) => {
-  const dirname = path.dirname(newpath);
-
-  fs.mkdirSync(dirname, { recursive: true });
-
   return new Promise((resolve, reject) => {
+    const dirname = path.dirname(newpath);
+
+    fs.mkdirSync(dirname, { recursive: true });
+
     const filename = path.basename(filepath);
 
     if (fs.existsSync(filepath) && fs.lstatSync(filepath).isDirectory()) {
@@ -39,8 +39,8 @@ module.exports = (filepath, newpath, variables) => {
 
       try {
         const eval_content = ejs.render(content.toString(), variables);
-        newpath = path.join(path.dirname(newpath), filename.substr(1));
 
+        console.log(newpath);
         fs.writeFileSync(newpath, eval_content);
       } catch (err) {
         reject(err);

--- a/lib/eval.js
+++ b/lib/eval.js
@@ -6,9 +6,9 @@
  * @module eval
  */
 
-const fs = require("fs");
-const ejs = require("ejs");
-const path = require("path");
+const fs = require("fs")
+const ejs = require("ejs")
+const path = require("path")
 
 /**
  * Process only ejs files and copies to newpath
@@ -22,38 +22,38 @@ const path = require("path");
  */
 module.exports = (filepath, newpath, variables) => {
   return new Promise((resolve, reject) => {
-    const dirname = path.dirname(newpath);
+    const dirname = path.dirname(newpath)
 
-    fs.mkdirSync(dirname, { recursive: true });
+    fs.mkdirSync(dirname, { recursive: true })
 
-    const filename = path.basename(filepath);
+    const filename = path.basename(filepath)
 
-    if (fs.existsSync(filepath) && fs.lstatSync(filepath).isDirectory()) {
-      resolve();
+    if (fs.existsSync(filepath) && fs.lstatSync(filepath).isDirectory()){
+      resolve()
     }
 
-    if (filename[0] === "_") {
+    if (filename[0] === "_"){
       const content = fs.readFileSync(filepath, {
         encoding: "utf8",
-      });
+      })
 
       try {
-        const eval_content = ejs.render(content.toString(), variables);
+        const eval_content = ejs.render(content.toString(), variables)
 
-        fs.writeFileSync(newpath, eval_content);
-      } catch (err) {
-        reject(err);
+        fs.writeFileSync(newpath, eval_content)
+      } catch (err){
+        reject(err)
       }
 
-      return resolve();
+      return resolve()
     } else {
       try {
-        fs.copyFileSync(filepath, newpath);
-      } catch (err) {
-        reject(err);
+        fs.copyFileSync(filepath, newpath)
+      } catch (err){
+        reject(err)
       }
     }
 
-    resolve();
-  });
-};
+    resolve()
+  })
+}

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -7,8 +7,8 @@
 
 /**
  * @typedef {object} Configuration
- * @property {boolean} overwrite - will overwrite the target directory if true, by default false
- * @property {object} variables - variables to be resolved in ejs template
+ * @property {boolean} [overwrite=false] - will overwrite the target directory if true, by default false
+ * @property {object} [variables = {}] - variables to be resolved in ejs template
  */
 
 const fs = require("fs")
@@ -17,6 +17,11 @@ const glob = require("fast-glob")
 const evaluate = require("./eval.js")
 
 class Generator{
+  /**
+   * @param {string} templateDir
+   * @param {string} outDir
+   * @param {Configuration} config
+   */
   constructor(templateDir, outDir, config){
     this.templateDir = templateDir
     this.outDir = outDir

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -74,11 +74,7 @@ class Generator{
 
     for (const item of res){
       let filename = path.basename(item)
-      let newPath = outpath
-
-      if (outIsFile){
-        newPath = path.join(outpath, filename)
-      }
+      let newPath = outIsFile ? path.join(outpath, filename) : outpath
 
       this.fileMap[item] = newPath
     }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -85,7 +85,7 @@ class Generator {
   }
 
   add(src, target){
-    this.#walk(src, target)
+    this.#walk(src, path.join(this.outDir, target))
 
     return this;
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -16,6 +16,92 @@ const path = require("path");
 const glob = require("glob");
 const evaluate = require("./eval.js");
 
+class Generator {
+  constructor(templateDir, outDir, config){
+    this.templateDir = templateDir;
+    this.outDir = outDir;
+    this.config = config;
+    this.fileMap = {};
+
+    this.#init("**/*", outDir)
+  }
+
+  #init(wpath, outpath){
+    const res = glob.sync(wpath, { cwd: this.templateDir });
+
+    for(const item of res){
+      const stats = fs.lstatSync(path.join(this.templateDir, item));
+
+      if(stats.isFile()){
+        let dirname = path.dirname(item);
+        let filename = path.basename(item);
+        if(filename[0] === "_"){
+          filename = filename.substr(1);
+        }
+
+        let newPath = path.join(outpath, dirname, filename);
+
+        this.fileMap[item] = newPath;
+      }
+    }
+  }
+
+  #walk(wpath, outpath){
+    const res = glob.sync(wpath, { cwd: this.templateDir });
+
+    for(const item of res){
+      const stats = fs.lstatSync(path.join(this.templateDir, item));
+
+      if(stats.isFile()){
+        let dirname = path.dirname(item);
+        let filename = path.basename(item);
+        let newPath = outpath;
+
+        if(outpath[outpath.length - 1] === "/"){
+          newPath = path.join(outpath, dirname, filename);
+        }
+
+        this.fileMap[item] = newPath;
+      }
+    }
+  }
+
+  #remove(wpath){
+    const res = glob.sync(wpath, { cwd: this.templateDir });
+
+    for(const item of res){
+      const stats = fs.lstatSync(path.join(this.templateDir, item));
+
+      if(stats.isFile()){
+        delete this.fileMap[item]
+      }
+    }
+  }
+
+  add(src, target){
+    this.#walk(src, target)
+
+    return this;
+  }
+
+  ignore(src){
+    this.#remove(src)
+
+    return this;
+  }
+
+  async then(resolve, reject){
+    const promises = [];
+
+    for(const src in this.fileMap){
+      promises.push(evaluate(path.join(this.templateDir, src), this.fileMap[src], this.config.variables));
+    }
+
+    await Promise.all(promises);
+    resolve(this.fileMap)
+  }
+}
+
 /**
  * Generates a project from the template
  *
@@ -36,37 +122,47 @@ module.exports = (
     variables: {},
   }
 ) => {
-  return new Promise((resolve, reject) => {
-    fs.access(templateDir, (err) => {
-      if (err) return reject(err);
-    });
+  const generator = new Generator(templateDir, outDir, config);
 
-    const options = {
-      recursive: config.overwrite,
-    };
+  return generator;
+//   return new Promise((resolve, reject) => {
+//     glob("**/*", { cwd: templateDir }, async (err, res) => {
+//       if(err) return reject(err);
 
-    fs.mkdir(outDir, options, (err) => {
-      if (err) return reject(err);
+//       for(const path of res){
+//         console.log(path)
+//       }
+//     })
+//     fs.access(templateDir, (err) => {
+//       if (err) return reject(err);
+//     });
 
-      outDir = path.resolve(outDir);
+//     const options = {
+//       recursive: config.overwrite,
+//     };
 
-      glob("**/*", { cwd: templateDir }, async (err, res) => {
-        if (err) return reject(err);
+//     fs.mkdir(outDir, options, (err) => {
+//       if (err) return reject(err);
 
-        for (const file of res) {
-          const filepath = path.join(templateDir, file);
+//       outDir = path.resolve(outDir);
 
-          const newpath = path.join(outDir, file);
+//       glob("**/*", { cwd: templateDir }, async (err, res) => {
+//         if (err) return reject(err);
 
-          try {
-            await evaluate(filepath, newpath, config.variables);
-          } catch (err) {
-            return reject(err);
-          }
-        }
+//         for (const file of res) {
+//           const filepath = path.join(templateDir, file);
 
-        resolve();
-      });
-    });
-  });
+//           const newpath = path.join(outDir, file);
+
+//           try {
+//             await evaluate(filepath, newpath, config.variables);
+//           } catch (err) {
+//             return reject(err);
+//           }
+//         }
+
+//         resolve();
+//       });
+//     });
+//   });
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -70,13 +70,13 @@ class Generator{
    */
   walk(wpath, outpath){
     const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+    const outIsFile = outpath.endsWith(path.sep)
+
     for (const item of res){
       let filename = path.basename(item)
       let newPath = outpath
 
-      const last_char = outpath[outpath.length - 1]
-
-      if (last_char === "/" || last_char === "\\"){
+      if (outIsFile){
         newPath = path.join(outpath, filename)
       }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -64,7 +64,7 @@ class Generator {
         let newPath = outpath;
 
         if(outpath[outpath.length - 1] === "/"){
-          newPath = path.join(outpath, dirname, filename);
+          newPath = path.join(outpath, filename);
         }
 
         this.fileMap[item] = newPath;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -11,19 +11,19 @@
  * @property {object} variables - variables to be resolved in ejs template
  */
 
-const fs = require("fs");
-const path = require("path");
-const glob = require("fast-glob");
-const evaluate = require("./eval.js");
+const fs = require("fs")
+const path = require("path")
+const glob = require("fast-glob")
+const evaluate = require("./eval.js")
 
-class Generator {
-  constructor(templateDir, outDir, config) {
-    this.templateDir = templateDir;
-    this.outDir = outDir;
-    this.config = config;
-    this.fileMap = {};
+class Generator{
+  constructor(templateDir, outDir, config){
+    this.templateDir = templateDir
+    this.outDir = outDir
+    this.config = config
+    this.fileMap = {}
 
-    this.init("**/*", outDir);
+    this.init("**/*", outDir)
   }
 
   /**
@@ -33,28 +33,28 @@ class Generator {
    * @param {string} outpath
    * @returns {Generator}
    */
-  init(wpath, outpath) {
+  init(wpath, outpath){
     const options = {
       recursive: this.config.overwrite,
-    };
-
-    fs.mkdirSync(this.outDir, options);
-
-    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
-
-    for (const item of res) {
-      let dirname = path.dirname(item);
-      let filename = path.basename(item);
-      if (filename[0] === "_") {
-        filename = filename.substr(1);
-      }
-
-      let newPath = path.join(outpath, dirname, filename);
-
-      this.fileMap[item] = newPath;
     }
 
-    return this;
+    fs.mkdirSync(this.outDir, options)
+
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+
+    for (const item of res){
+      let dirname = path.dirname(item)
+      let filename = path.basename(item)
+      if (filename[0] === "_"){
+        filename = filename.substr(1)
+      }
+
+      let newPath = path.join(outpath, dirname, filename)
+
+      this.fileMap[item] = newPath
+    }
+
+    return this
   }
 
   /**
@@ -63,18 +63,17 @@ class Generator {
    * @param {string} wpath
    * @param {string} outpath
    */
-  walk(wpath, outpath) {
-    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
-    for (const item of res) {
-      let dirname = path.dirname(item);
-      let filename = path.basename(item);
-      let newPath = outpath;
+  walk(wpath, outpath){
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+    for (const item of res){
+      let filename = path.basename(item)
+      let newPath = outpath
 
-      if (outpath[outpath.length - 1] === "/") {
-        newPath = path.join(outpath, filename);
+      if (outpath[outpath.length - 1] === "/"){
+        newPath = path.join(outpath, filename)
       }
 
-      this.fileMap[item] = newPath;
+      this.fileMap[item] = newPath
     }
   }
 
@@ -83,10 +82,10 @@ class Generator {
    *
    * @param {string} wpath
    */
-  remove(wpath) {
-    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
-    for (const item of res) {
-      delete this.fileMap[item];
+  remove(wpath){
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+    for (const item of res){
+      delete this.fileMap[item]
     }
   }
 
@@ -97,10 +96,10 @@ class Generator {
    * @param {string} target
    * @returns {Generator}
    */
-  add(src, target) {
-    this.walk(src, path.join(this.outDir, target));
+  add(src, target){
+    this.walk(src, path.join(this.outDir, target))
 
-    return this;
+    return this
   }
 
   /**
@@ -109,29 +108,29 @@ class Generator {
    * @param {string} src
    * @returns {Generator}
    */
-  ignore(src) {
-    this.remove(src);
+  ignore(src){
+    this.remove(src)
 
-    return this;
+    return this
   }
 
   /**
    * @param {Function} resolve
    */
-  async then(resolve) {
-    const promises = [];
-    for (const src in this.fileMap) {
+  async then(resolve){
+    const promises = []
+    for (const src in this.fileMap){
       promises.push(
         evaluate(
           path.join(this.templateDir, src),
           this.fileMap[src],
           this.config.variables
         )
-      );
+      )
     }
 
-    await Promise.all(promises);
-    resolve(this.fileMap);
+    await Promise.all(promises)
+    resolve(this.fileMap)
   }
 }
 
@@ -155,7 +154,7 @@ module.exports = (
     variables: {},
   }
 ) => {
-  const generator = new Generator(templateDir, outDir, config);
+  const generator = new Generator(templateDir, outDir, config)
 
-  return generator;
-};
+  return generator
+}

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -27,6 +27,12 @@ class Generator {
   }
 
   #init(wpath, outpath){
+    const options = {
+      recursive: this.config.overwrite
+    };
+
+    fs.mkdirSync(this.outDir, options);
+
     const res = glob.sync(wpath, { cwd: this.templateDir });
 
     for(const item of res){
@@ -123,6 +129,5 @@ module.exports = (
   }
 ) => {
   const generator = new Generator(templateDir, outDir, config);
-
   return generator;
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -125,44 +125,4 @@ module.exports = (
   const generator = new Generator(templateDir, outDir, config);
 
   return generator;
-//   return new Promise((resolve, reject) => {
-//     glob("**/*", { cwd: templateDir }, async (err, res) => {
-//       if(err) return reject(err);
-
-//       for(const path of res){
-//         console.log(path)
-//       }
-//     })
-//     fs.access(templateDir, (err) => {
-//       if (err) return reject(err);
-//     });
-
-//     const options = {
-//       recursive: config.overwrite,
-//     };
-
-//     fs.mkdir(outDir, options, (err) => {
-//       if (err) return reject(err);
-
-//       outDir = path.resolve(outDir);
-
-//       glob("**/*", { cwd: templateDir }, async (err, res) => {
-//         if (err) return reject(err);
-
-//         for (const file of res) {
-//           const filepath = path.join(templateDir, file);
-
-//           const newpath = path.join(outDir, file);
-
-//           try {
-//             await evaluate(filepath, newpath, config.variables);
-//           } catch (err) {
-//             return reject(err);
-//           }
-//         }
-
-//         resolve();
-//       });
-//     });
-//   });
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -74,7 +74,9 @@ class Generator{
       let filename = path.basename(item)
       let newPath = outpath
 
-      if (outpath[outpath.length - 1] === "/"){
+      const last_char = outpath[outpath.length - 1]
+
+      if (last_char === "/" || last_char === "\\"){
         newPath = path.join(outpath, filename)
       }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -26,6 +26,13 @@ class Generator {
     this.init("**/*", outDir);
   }
 
+  /**
+   * Setup generator
+   *
+   * @param {string} wpath
+   * @param {string} outpath
+   * @returns {Generator}
+   */
   init(wpath, outpath) {
     const options = {
       recursive: this.config.overwrite,
@@ -50,6 +57,12 @@ class Generator {
     return this;
   }
 
+  /**
+   * Walks through wpath and adds files to fileMap
+   *
+   * @param {string} wpath
+   * @param {string} outpath
+   */
   walk(wpath, outpath) {
     const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
     for (const item of res) {
@@ -65,6 +78,11 @@ class Generator {
     }
   }
 
+  /**
+   * Removes files described by wpath from fileMap
+   *
+   * @param {string} wpath
+   */
   remove(wpath) {
     const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
     for (const item of res) {
@@ -72,19 +90,35 @@ class Generator {
     }
   }
 
+  /**
+   * Map files in src with target folder in and store it in fileMap
+   *
+   * @param {string} src
+   * @param {string} target
+   * @returns {Generator}
+   */
   add(src, target) {
     this.walk(src, path.join(this.outDir, target));
 
     return this;
   }
 
+  /**
+   * Remove files from fileMap
+   *
+   * @param {string} src
+   * @returns {Generator}
+   */
   ignore(src) {
     this.remove(src);
 
     return this;
   }
 
-  async then(resolve, reject) {
+  /**
+   * @param {Function} resolve
+   */
+  async then(resolve) {
     const promises = [];
     for (const src in this.fileMap) {
       promises.push(

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -13,98 +13,91 @@
 
 const fs = require("fs");
 const path = require("path");
-const glob = require("glob");
+const glob = require("fast-glob");
 const evaluate = require("./eval.js");
 
 class Generator {
-  constructor(templateDir, outDir, config){
+  constructor(templateDir, outDir, config) {
     this.templateDir = templateDir;
     this.outDir = outDir;
     this.config = config;
     this.fileMap = {};
 
-    this.#init("**/*", outDir)
+    this.init("**/*", outDir);
   }
 
-  #init(wpath, outpath){
+  init(wpath, outpath) {
     const options = {
-      recursive: this.config.overwrite
+      recursive: this.config.overwrite,
     };
 
     fs.mkdirSync(this.outDir, options);
 
-    const res = glob.sync(wpath, { cwd: this.templateDir });
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
 
-    for(const item of res){
-      const stats = fs.lstatSync(path.join(this.templateDir, item));
-
-      if(stats.isFile()){
-        let dirname = path.dirname(item);
-        let filename = path.basename(item);
-        if(filename[0] === "_"){
-          filename = filename.substr(1);
-        }
-
-        let newPath = path.join(outpath, dirname, filename);
-
-        this.fileMap[item] = newPath;
+    for (const item of res) {
+      let dirname = path.dirname(item);
+      let filename = path.basename(item);
+      if (filename[0] === "_") {
+        filename = filename.substr(1);
       }
+
+      let newPath = path.join(outpath, dirname, filename);
+
+      this.fileMap[item] = newPath;
     }
-  }
-
-  #walk(wpath, outpath){
-    const res = glob.sync(wpath, { cwd: this.templateDir });
-
-    for(const item of res){
-      const stats = fs.lstatSync(path.join(this.templateDir, item));
-
-      if(stats.isFile()){
-        let dirname = path.dirname(item);
-        let filename = path.basename(item);
-        let newPath = outpath;
-
-        if(outpath[outpath.length - 1] === "/"){
-          newPath = path.join(outpath, filename);
-        }
-
-        this.fileMap[item] = newPath;
-      }
-    }
-  }
-
-  #remove(wpath){
-    const res = glob.sync(wpath, { cwd: this.templateDir });
-
-    for(const item of res){
-      const stats = fs.lstatSync(path.join(this.templateDir, item));
-
-      if(stats.isFile()){
-        delete this.fileMap[item]
-      }
-    }
-  }
-
-  add(src, target){
-    this.#walk(src, path.join(this.outDir, target))
 
     return this;
   }
 
-  ignore(src){
-    this.#remove(src)
+  walk(wpath, outpath) {
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
+    for (const item of res) {
+      let dirname = path.dirname(item);
+      let filename = path.basename(item);
+      let newPath = outpath;
+
+      if (outpath[outpath.length - 1] === "/") {
+        newPath = path.join(outpath, filename);
+      }
+
+      this.fileMap[item] = newPath;
+    }
+  }
+
+  remove(wpath) {
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true });
+    for (const item of res) {
+      delete this.fileMap[item];
+    }
+  }
+
+  add(src, target) {
+    this.walk(src, path.join(this.outDir, target));
 
     return this;
   }
 
-  async then(resolve, reject){
+  ignore(src) {
+    this.remove(src);
+
+    return this;
+  }
+
+  async then(resolve, reject) {
     const promises = [];
-
-    for(const src in this.fileMap){
-      promises.push(evaluate(path.join(this.templateDir, src), this.fileMap[src], this.config.variables));
+    for (const src in this.fileMap) {
+      promises.push(
+        evaluate(
+          path.join(this.templateDir, src),
+          this.fileMap[src],
+          this.config.variables
+        )
+      );
     }
 
     await Promise.all(promises);
-    resolve(this.fileMap)
+    resolve(this.fileMap);
   }
 }
 
@@ -118,7 +111,7 @@ class Generator {
  * @param {string} outDir - Output directory
  * @param {Configuration} config - Map from variable to its value;
  *
- * @returns {Promise<void>}
+ * @returns {Generator}
  */
 module.exports = (
   templateDir,
@@ -129,5 +122,6 @@ module.exports = (
   }
 ) => {
   const generator = new Generator(templateDir, outDir, config);
+
   return generator;
 };

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -127,3 +127,38 @@ test("throws error if target directory already exist", async () => {
     expect(err.code).toBe("EEXIST");
   }
 });
+
+test("don't add file if ignored", async () => {
+  expect.assertions(1);
+
+  const s = generator("/template", "app", {
+    overwrite: true,
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  });
+
+  s.ignore("src/main.js");
+
+  await s;
+
+  expect(fs.existsSync("app/src/main.js")).toBe(false);
+})
+
+test("copy file to a custom place", async () => {
+  expect.assertions(1);
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  })
+
+  s.add("src/main.js", "src/bleh.js");
+
+  await s;
+
+  expect(fs.existsSync("app/src/bleh.js")).toBe(true);
+})

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -4,13 +4,23 @@ const fs = require("fs");
 
 beforeEach(async () => {
   mock({
+    "/common": {
+      js: {
+        "one.js": `console.log("this is one.js")`,
+        "two.js": `console.log("this is two.js")`,
+        "three.js": `console.log("this is three.js")`,
+        "one.ts": `console.log("this is one.ts")`,
+        "two.ts": `console.log("this is two.ts")`,
+        "three.ts": `console.log("this is three.ts")`
+      }
+    },
     "/template": {
       src: {
         "main.js": `console.log("hey!");`,
         "_index.js": `console.log("<%= name %> v<%= version %>");`,
         dist: {
           "index.html": "<html></html>",
-        },
+        }
       },
       "_package.json": `
         {
@@ -161,4 +171,23 @@ test("copy file to a custom place", async () => {
   await s;
 
   expect(fs.existsSync("app/src/bleh.js")).toBe(true);
+})
+
+test("glob pattern is working", async () => {
+  expect.assertions(3);
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    }
+  })
+
+  s.add("../common/**/*.js", "scripts/");
+
+  await s;
+
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
 })

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -278,3 +278,31 @@ test("ignore multiple files of certain extension", async() => {
   expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
   expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
 })
+
+test("content of explicitly added files from common folder is correct", async() => {
+  expect.assertions(3)
+
+  const s = generator("template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  })
+
+  s.add("../common/js/*", "scripts/")
+  s.ignore("../common/js/*.(ts|mjs)")
+
+  await s
+
+  expect(fs.readFileSync("app/scripts/one.js", {
+    encoding: "utf8",
+  })).toBe("console.log(\"this is one.js\")")
+
+  expect(fs.readFileSync("app/scripts/two.js", {
+    encoding: "utf8",
+  })).toBe("console.log(\"this is two.js\")")
+
+  expect(fs.readFileSync("app/scripts/three.js", {
+    encoding: "utf8",
+  })).toBe("console.log(\"this is three.js\")")
+})

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -1,5 +1,6 @@
 const generator = require("./generator")
 const mock = require("mock-fs")
+const path = require("path")
 const fs = require("fs")
 
 beforeEach(async() => {
@@ -191,15 +192,15 @@ test("glob pattern is working", async() => {
 
   await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(false)
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(false)
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(false)
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
 })
 
 test("adding multiple files to the same folder", async() => {
@@ -217,15 +218,15 @@ test("adding multiple files to the same folder", async() => {
 
   await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(true)
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(true)
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(true)
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
 })
 
 test("matching multiple files of different extensions using glob", async() => {
@@ -242,15 +243,15 @@ test("matching multiple files of different extensions using glob", async() => {
 
   await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(true)
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(true)
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(true)
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
 })
 
 test("ignore multiple files of certain extension", async() => {
@@ -268,13 +269,13 @@ test("ignore multiple files of certain extension", async() => {
 
   await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(false)
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(false)
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(false)
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
+  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
+  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
 })

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -174,6 +174,7 @@ test("copy file to a custom place", async() => {
   await s
 
   expect(fs.existsSync("app/src/bleh.js")).toBe(true)
+  expect(fs.existsSync("app/src/main.js")).toBe(false)
 })
 
 test("glob pattern is working", async() => {

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -264,7 +264,7 @@ test("ignore multiple files of certain extension", async() => {
   })
 
   s.add("../common/js/*", "scripts/")
-  s.ignore("../common/js/*.(ts|mjs)", "scripts/")
+  s.ignore("../common/js/*.(ts|mjs)")
 
   await s
 

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -113,15 +113,17 @@ test("overwrite file if already exist; on overwrite = true", async () => {
   });
 });
 
-test("throws error if target already exist on", async () => {
+test("throws error if target directory already exist", async () => {
   expect.assertions(1);
 
-  return generator("/template", "test-app", {
-    variables: {
-      name: "sinix",
-      version: "0.1.0",
-    },
-  }).catch((err) => {
+  try {
+    await generator("/template", "test-app", {
+      variables: {
+        name: "sinix",
+        version: "0.1.0",
+      },
+    })
+  } catch(err) {
     expect(err.code).toBe("EEXIST");
-  });
+  }
 });

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -1,26 +1,26 @@
-const generator = require("./generator");
-const mock = require("mock-fs");
-const fs = require("fs");
+const generator = require("./generator")
+const mock = require("mock-fs")
+const fs = require("fs")
 
-beforeEach(async () => {
+beforeEach(async() => {
   mock({
     "/common": {
       js: {
-        "one.js": `console.log("this is one.js")`,
-        "two.js": `console.log("this is two.js")`,
-        "three.js": `console.log("this is three.js")`,
-        "one.ts": `console.log("this is one.ts")`,
-        "two.ts": `console.log("this is two.ts")`,
-        "three.ts": `console.log("this is three.ts")`,
-        "one.mjs": `console.log("this is one.mjs")`,
-        "two.mjs": `console.log("this is two.mjs")`,
-        "three.mjs": `console.log("this is three.mjs")`,
+        "one.js": "console.log(\"this is one.js\")",
+        "two.js": "console.log(\"this is two.js\")",
+        "three.js": "console.log(\"this is three.js\")",
+        "one.ts": "console.log(\"this is one.ts\")",
+        "two.ts": "console.log(\"this is two.ts\")",
+        "three.ts": "console.log(\"this is three.ts\")",
+        "one.mjs": "console.log(\"this is one.mjs\")",
+        "two.mjs": "console.log(\"this is two.mjs\")",
+        "three.mjs": "console.log(\"this is three.mjs\")",
       },
     },
     "/template": {
       src: {
-        "main.js": 'console.log("hey!");',
-        "_index.js": 'console.log("<%= name %> v<%= version %>");',
+        "main.js": "console.log(\"hey!\");",
+        "_index.js": "console.log(\"<%= name %> v<%= version %>\");",
         dist: {
           "index.html": "<html></html>",
         },
@@ -34,25 +34,25 @@ beforeEach(async () => {
     },
     "/conflict-template": {
       src: {
-        "_index.js": 'console.log("<%= name %> v<%= version %>");',
-        "index.js": 'console.log("<%= name %> v<%= version %>");',
+        "_index.js": "console.log(\"<%= name %> v<%= version %>\");",
+        "index.js": "console.log(\"<%= name %> v<%= version %>\");",
       },
     },
     "test-app": {
       src: {
-        "index.js": 'console.log("nothing")',
+        "index.js": "console.log(\"nothing\")",
         "test.js": "// this is supposed to be prebuilt file",
       },
     },
-  });
-});
+  })
+})
 
-afterEach(async () => {
-  mock.restore();
-});
+afterEach(async() => {
+  mock.restore()
+})
 
-test("folder name is correct", async () => {
-  expect.assertions(1);
+test("folder name is correct", async() => {
+  expect.assertions(1)
 
   return generator("/template", "app", {
     variables: {
@@ -61,15 +61,15 @@ test("folder name is correct", async () => {
     },
   })
     .then(() => {
-      expect(fs.existsSync("app")).toBe(true);
+      expect(fs.existsSync("app")).toBe(true)
     })
     .catch((err) => {
-      expect(err).toBeFalsy();
-    });
-});
+      expect(err).toBeFalsy()
+    })
+})
 
-test("created file from ejs template has correct content based on variables", async () => {
-  expect.assertions(1);
+test("created file from ejs template has correct content based on variables", async() => {
+  expect.assertions(1)
 
   return generator("/template", "app", {
     variables: {
@@ -79,19 +79,19 @@ test("created file from ejs template has correct content based on variables", as
   }).then(() => {
     const content = fs.readFileSync("./app/package.json", {
       encoding: "utf8",
-    });
+    })
 
     expect(content).toBe(`
         {
           "name": "sinix",
           "version": "0.1.0"
         }
-      `);
-  });
-});
+      `)
+  })
+})
 
-test("files which aren't a part of template stays intact on overwrite", async () => {
-  expect.assertions(1);
+test("files which aren't a part of template stays intact on overwrite", async() => {
+  expect.assertions(1)
 
   return generator("/template", "test-app", {
     overwrite: true,
@@ -102,14 +102,14 @@ test("files which aren't a part of template stays intact on overwrite", async ()
   }).then(() => {
     const content = fs.readFileSync("./test-app/src/test.js", {
       encoding: "utf8",
-    });
+    })
 
-    expect(content).toBe("// this is supposed to be prebuilt file");
-  });
-});
+    expect(content).toBe("// this is supposed to be prebuilt file")
+  })
+})
 
-test("overwrite file if already exist; on overwrite = true", async () => {
-  expect.assertions(1);
+test("overwrite file if already exist; on overwrite = true", async() => {
+  expect.assertions(1)
 
   return generator("/template", "test-app", {
     overwrite: true,
@@ -120,14 +120,14 @@ test("overwrite file if already exist; on overwrite = true", async () => {
   }).then(() => {
     const content = fs.readFileSync("./test-app/src/index.js", {
       encoding: "utf8",
-    });
+    })
 
-    expect(content).toBe('console.log("sinix v0.1.0");');
-  });
-});
+    expect(content).toBe("console.log(\"sinix v0.1.0\");")
+  })
+})
 
-test("throws error if target directory already exist", async () => {
-  expect.assertions(1);
+test("throws error if target directory already exist", async() => {
+  expect.assertions(1)
 
   try {
     await generator("/template", "test-app", {
@@ -135,14 +135,14 @@ test("throws error if target directory already exist", async () => {
         name: "sinix",
         version: "0.1.0",
       },
-    });
-  } catch (err) {
-    expect(err.code).toBe("EEXIST");
+    })
+  } catch (err){
+    expect(err.code).toBe("EEXIST")
   }
-});
+})
 
-test("don't add file if ignored", async () => {
-  expect.assertions(1);
+test("don't add file if ignored", async() => {
+  expect.assertions(1)
 
   const s = generator("/template", "app", {
     overwrite: true,
@@ -150,130 +150,130 @@ test("don't add file if ignored", async () => {
       name: "sinix",
       version: "0.1.0",
     },
-  });
+  })
 
-  s.ignore("src/main.js");
+  s.ignore("src/main.js")
 
-  await s;
+  await s
 
-  expect(fs.existsSync("app/src/main.js")).toBe(false);
-});
+  expect(fs.existsSync("app/src/main.js")).toBe(false)
+})
 
-test("copy file to a custom place", async () => {
-  expect.assertions(1);
-
-  const s = generator("/template", "app", {
-    variables: {
-      name: "sinix",
-      version: "0.1.0",
-    },
-  });
-
-  s.add("src/main.js", "src/bleh.js");
-
-  await s;
-
-  expect(fs.existsSync("app/src/bleh.js")).toBe(true);
-});
-
-test("glob pattern is working", async () => {
-  expect.assertions(9);
+test("copy file to a custom place", async() => {
+  expect.assertions(1)
 
   const s = generator("/template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
     },
-  });
+  })
 
-  s.add("../common/**/*.js", "scripts/");
+  s.add("src/main.js", "src/bleh.js")
 
-  await s;
+  await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(false);
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(false);
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(false);
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
-});
+  expect(fs.existsSync("app/src/bleh.js")).toBe(true)
+})
 
-test("adding multiple files to the same folder", async () => {
-  expect.assertions(9);
+test("glob pattern is working", async() => {
+  expect.assertions(9)
 
   const s = generator("/template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
     },
-  });
+  })
 
-  s.add("../common/js/*.js", "scripts/");
-  s.add("../common/js/*.ts", "scripts/");
+  s.add("../common/**/*.js", "scripts/")
 
-  await s;
+  await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(true);
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(true);
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(true);
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
-});
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+})
 
-test("matching multiple files of different extensions using glob", async () => {
-  expect.assertions(9);
-
-  const s = generator("/template", "app", {
-    variables: {
-      name: "sinix",
-      version: "0.1.0",
-    },
-  });
-
-  s.add("../common/js/*.(js|ts)", "scripts/");
-
-  await s;
-
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(true);
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(true);
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(true);
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
-});
-
-test("ignore multiple files of certain extension", async () => {
-  expect.assertions(9);
+test("adding multiple files to the same folder", async() => {
+  expect.assertions(9)
 
   const s = generator("/template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
     },
-  });
+  })
 
-  s.add("../common/js/*", "scripts/");
-  s.ignore("../common/js/*.(ts|mjs)", "scripts/");
+  s.add("../common/js/*.js", "scripts/")
+  s.add("../common/js/*.ts", "scripts/")
 
-  await s;
+  await s
 
-  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
-  expect(fs.existsSync("app/scripts/one.ts")).toBe(false);
-  expect(fs.existsSync("app/scripts/two.ts")).toBe(false);
-  expect(fs.existsSync("app/scripts/three.ts")).toBe(false);
-  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
-  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
-});
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+})
+
+test("matching multiple files of different extensions using glob", async() => {
+  expect.assertions(9)
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  })
+
+  s.add("../common/js/*.(js|ts)", "scripts/")
+
+  await s
+
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+})
+
+test("ignore multiple files of certain extension", async() => {
+  expect.assertions(9)
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  })
+
+  s.add("../common/js/*", "scripts/")
+  s.ignore("../common/js/*.(ts|mjs)", "scripts/")
+
+  await s
+
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
+})

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -251,3 +251,29 @@ test("matching multiple files of different extensions using glob", async () => {
   expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
   expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
 });
+
+test("ignore multiple files of certain extension", async () => {
+  expect.assertions(9);
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  });
+
+  s.add("../common/js/*", "scripts/");
+  s.ignore("../common/js/*.(ts|mjs)", "scripts/");
+
+  await s;
+
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(false);
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(false);
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(false);
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
+});

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -1,6 +1,5 @@
 const generator = require("./generator")
 const mock = require("mock-fs")
-const path = require("path")
 const fs = require("fs")
 
 beforeEach(async() => {
@@ -192,15 +191,15 @@ test("glob pattern is working", async() => {
 
   await s
 
-  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
 })
 
 test("adding multiple files to the same folder", async() => {
@@ -218,15 +217,15 @@ test("adding multiple files to the same folder", async() => {
 
   await s
 
-  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
 })
 
 test("matching multiple files of different extensions using glob", async() => {
@@ -243,15 +242,15 @@ test("matching multiple files of different extensions using glob", async() => {
 
   await s
 
-  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
 })
 
 test("ignore multiple files of certain extension", async() => {
@@ -269,13 +268,13 @@ test("ignore multiple files of certain extension", async() => {
 
   await s
 
-  expect(fs.existsSync(path.resolve("app/scripts/one.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/two.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/three.js"))).toBe(true)
-  expect(fs.existsSync(path.resolve("app/scripts/one.ts"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/two.ts"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/three.ts"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/one.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/two.mjs"))).toBe(false)
-  expect(fs.existsSync(path.resolve("app/scripts/three.mjs"))).toBe(false)
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true)
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(false)
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false)
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false)
 })

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -11,8 +11,11 @@ beforeEach(async () => {
         "three.js": `console.log("this is three.js")`,
         "one.ts": `console.log("this is one.ts")`,
         "two.ts": `console.log("this is two.ts")`,
-        "three.ts": `console.log("this is three.ts")`
-      }
+        "three.ts": `console.log("this is three.ts")`,
+        "one.mjs": `console.log("this is one.mjs")`,
+        "two.mjs": `console.log("this is two.mjs")`,
+        "three.mjs": `console.log("this is three.mjs")`,
+      },
     },
     "/template": {
       src: {
@@ -20,7 +23,7 @@ beforeEach(async () => {
         "_index.js": `console.log("<%= name %> v<%= version %>");`,
         dist: {
           "index.html": "<html></html>",
-        }
+        },
       },
       "_package.json": `
         {
@@ -132,8 +135,8 @@ test("throws error if target directory already exist", async () => {
         name: "sinix",
         version: "0.1.0",
       },
-    })
-  } catch(err) {
+    });
+  } catch (err) {
     expect(err.code).toBe("EEXIST");
   }
 });
@@ -154,7 +157,7 @@ test("don't add file if ignored", async () => {
   await s;
 
   expect(fs.existsSync("app/src/main.js")).toBe(false);
-})
+});
 
 test("copy file to a custom place", async () => {
   expect.assertions(1);
@@ -164,24 +167,24 @@ test("copy file to a custom place", async () => {
       name: "sinix",
       version: "0.1.0",
     },
-  })
+  });
 
   s.add("src/main.js", "src/bleh.js");
 
   await s;
 
   expect(fs.existsSync("app/src/bleh.js")).toBe(true);
-})
+});
 
 test("glob pattern is working", async () => {
-  expect.assertions(3);
+  expect.assertions(9);
 
   const s = generator("/template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
-    }
-  })
+    },
+  });
 
   s.add("../common/**/*.js", "scripts/");
 
@@ -190,4 +193,61 @@ test("glob pattern is working", async () => {
   expect(fs.existsSync("app/scripts/one.js")).toBe(true);
   expect(fs.existsSync("app/scripts/two.js")).toBe(true);
   expect(fs.existsSync("app/scripts/three.js")).toBe(true);
-})
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(false);
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(false);
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(false);
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
+});
+
+test("adding multiple files to the same folder", async () => {
+  expect.assertions(9);
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  });
+
+  s.add("../common/js/*.js", "scripts/");
+  s.add("../common/js/*.ts", "scripts/");
+
+  await s;
+
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(true);
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(true);
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(true);
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
+});
+
+test("matching multiple files of different extensions using glob", async () => {
+  expect.assertions(9);
+
+  const s = generator("/template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+  });
+
+  s.add("../common/js/*.(js|ts)", "scripts/");
+
+  await s;
+
+  expect(fs.existsSync("app/scripts/one.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/two.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/three.js")).toBe(true);
+  expect(fs.existsSync("app/scripts/one.ts")).toBe(true);
+  expect(fs.existsSync("app/scripts/two.ts")).toBe(true);
+  expect(fs.existsSync("app/scripts/three.ts")).toBe(true);
+  expect(fs.existsSync("app/scripts/one.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/two.mjs")).toBe(false);
+  expect(fs.existsSync("app/scripts/three.mjs")).toBe(false);
+});

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -160,7 +160,7 @@ test("don't add file if ignored", async() => {
 })
 
 test("copy file to a custom place", async() => {
-  expect.assertions(1)
+  expect.assertions(2)
 
   const s = generator("/template", "app", {
     variables: {

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -4,7 +4,7 @@ const fs = require("fs")
 
 beforeEach(async() => {
   mock({
-    "/common": {
+    "common": {
       js: {
         "one.js": "console.log(\"this is one.js\")",
         "two.js": "console.log(\"this is two.js\")",
@@ -17,7 +17,7 @@ beforeEach(async() => {
         "three.mjs": "console.log(\"this is three.mjs\")",
       },
     },
-    "/template": {
+    "template": {
       src: {
         "main.js": "console.log(\"hey!\");",
         "_index.js": "console.log(\"<%= name %> v<%= version %>\");",
@@ -32,7 +32,7 @@ beforeEach(async() => {
         }
       `,
     },
-    "/conflict-template": {
+    "conflict-template": {
       src: {
         "_index.js": "console.log(\"<%= name %> v<%= version %>\");",
         "index.js": "console.log(\"<%= name %> v<%= version %>\");",
@@ -54,7 +54,7 @@ afterEach(async() => {
 test("folder name is correct", async() => {
   expect.assertions(1)
 
-  return generator("/template", "app", {
+  return generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
@@ -71,7 +71,7 @@ test("folder name is correct", async() => {
 test("created file from ejs template has correct content based on variables", async() => {
   expect.assertions(1)
 
-  return generator("/template", "app", {
+  return generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
@@ -93,7 +93,7 @@ test("created file from ejs template has correct content based on variables", as
 test("files which aren't a part of template stays intact on overwrite", async() => {
   expect.assertions(1)
 
-  return generator("/template", "test-app", {
+  return generator("template", "test-app", {
     overwrite: true,
     variables: {
       name: "sinix",
@@ -111,7 +111,7 @@ test("files which aren't a part of template stays intact on overwrite", async() 
 test("overwrite file if already exist; on overwrite = true", async() => {
   expect.assertions(1)
 
-  return generator("/template", "test-app", {
+  return generator("template", "test-app", {
     overwrite: true,
     variables: {
       name: "sinix",
@@ -130,7 +130,7 @@ test("throws error if target directory already exist", async() => {
   expect.assertions(1)
 
   try {
-    await generator("/template", "test-app", {
+    await generator("template", "test-app", {
       variables: {
         name: "sinix",
         version: "0.1.0",
@@ -144,7 +144,7 @@ test("throws error if target directory already exist", async() => {
 test("don't add file if ignored", async() => {
   expect.assertions(1)
 
-  const s = generator("/template", "app", {
+  const s = generator("template", "app", {
     overwrite: true,
     variables: {
       name: "sinix",
@@ -162,7 +162,7 @@ test("don't add file if ignored", async() => {
 test("copy file to a custom place", async() => {
   expect.assertions(2)
 
-  const s = generator("/template", "app", {
+  const s = generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
@@ -180,7 +180,7 @@ test("copy file to a custom place", async() => {
 test("glob pattern is working", async() => {
   expect.assertions(9)
 
-  const s = generator("/template", "app", {
+  const s = generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
@@ -205,7 +205,7 @@ test("glob pattern is working", async() => {
 test("adding multiple files to the same folder", async() => {
   expect.assertions(9)
 
-  const s = generator("/template", "app", {
+  const s = generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
@@ -231,7 +231,7 @@ test("adding multiple files to the same folder", async() => {
 test("matching multiple files of different extensions using glob", async() => {
   expect.assertions(9)
 
-  const s = generator("/template", "app", {
+  const s = generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",
@@ -256,7 +256,7 @@ test("matching multiple files of different extensions using glob", async() => {
 test("ignore multiple files of certain extension", async() => {
   expect.assertions(9)
 
-  const s = generator("/template", "app", {
+  const s = generator("template", "app", {
     variables: {
       name: "sinix",
       version: "0.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/sinix-dev/scaffe.js#readme",
   "dependencies": {
     "ejs": "^3.1.5",
-    "glob": "^7.1.6"
+    "fast-glob": "^3.2.5"
   },
   "devDependencies": {
     "jest": "^26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,6 +483,27 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@nodelib/fs.scandir@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
+  integrity sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.4"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.4", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz#a3f2dd61bab43b8db8fa108a121cfffe4c676655"
+  integrity sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz#cce9396b30aa5afe9e3756608f5831adcb53d063"
+  integrity sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.4"
+    fastq "^1.6.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1395,6 +1416,18 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-glob@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1404,6 +1437,13 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.11.0.tgz#bb9fb955a07130a918eb63c1f5161cc32a5d0858"
+  integrity sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==
+  dependencies:
+    reusify "^1.0.4"
 
 fb-watchman@^2.0.0:
   version "2.0.1"
@@ -1526,7 +1566,14 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob-parent@^5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -1765,6 +1812,11 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
@@ -1774,6 +1826,13 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -2466,6 +2525,11 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
 micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
@@ -2778,6 +2842,11 @@ picomatch@^2.0.4, picomatch@^2.0.5:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
+picomatch@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
+
 pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -2842,6 +2911,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 react-is@^17.0.1:
   version "17.0.2"
@@ -2972,6 +3046,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -2983,6 +3062,13 @@ rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
@@ -153,7 +160,7 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
 
-"@babel/highlight@^7.12.13":
+"@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
   integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
@@ -295,6 +302,21 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -622,12 +644,17 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
+acorn-jsx@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@^7.1.1:
+acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -637,7 +664,7 @@ acorn@^8.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"
   integrity sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==
 
-ajv@^6.12.3:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -646,6 +673,21 @@ ajv@^6.12.3:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.1.0.tgz#45d5d3d36c7cdd808930cc3e603cf6200dbeb736"
+  integrity sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -732,6 +774,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async@0.9.x:
   version "0.9.2"
@@ -1093,7 +1140,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1142,7 +1189,7 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -1164,7 +1211,7 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -1211,6 +1258,13 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -1255,6 +1309,13 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+enquirer@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -1289,12 +1350,108 @@ escodegen@^2.0.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@^7.25.0:
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.25.0.tgz#1309e4404d94e676e3e831b3a3ad2b050031eb67"
+  integrity sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.21"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+  dependencies:
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
+
 esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-estraverse@^5.2.0:
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
+  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
@@ -1433,7 +1590,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -1451,6 +1608,13 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 filelist@^1.0.1:
   version "1.0.2"
@@ -1483,6 +1647,19 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -1525,6 +1702,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -1566,7 +1748,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -1589,6 +1771,20 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
+
+globals@^13.6.0:
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
+  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
+  dependencies:
+    type-fest "^0.20.2"
 
 graceful-fs@^4.2.4:
   version "4.2.6"
@@ -1698,6 +1894,19 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-local@^3.0.2:
   version "3.0.2"
@@ -1827,7 +2036,7 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -2401,10 +2610,20 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -2462,6 +2681,14 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -2482,7 +2709,22 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash@^4.17.19, lodash@^4.7.0:
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
+lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2758,6 +3000,18 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 p-each-series@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
@@ -2786,6 +3040,13 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-json@^5.0.0:
   version "5.2.0"
@@ -2866,6 +3127,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2880,6 +3146,11 @@ pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1:
   version "2.4.1"
@@ -2949,6 +3220,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -3011,6 +3287,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -3022,6 +3303,11 @@ resolve-cwd@^3.0.0:
   integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
   dependencies:
     resolve-from "^5.0.0"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-from@^5.0.0:
   version "5.0.0"
@@ -3051,7 +3337,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -3124,7 +3410,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -3189,6 +3475,15 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3371,6 +3666,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -3398,6 +3698,19 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+table@^6.0.4:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.5.1.tgz#930885a7430f15f8766b35cd1e36de40793db523"
+  integrity sha512-xGDXWTBJxahkzPQCsn1S9ESHEenU7TbMD5Iv4FeopXv/XwJyWatFjfbor+6ipI10/MNPXBYUamYukOrbPZ9L/w==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -3414,6 +3727,11 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 throat@^5.0.0:
   version "5.0.0"
@@ -3498,6 +3816,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -3509,6 +3834,11 @@ type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
@@ -3581,6 +3911,11 @@ uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^7.0.0:
   version "7.1.1"
@@ -3679,7 +4014,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
Changes in API

### Before
```js
await scaffe.generate(templateDir, outDir, { overwrite: true, variables: { name: "app" } });
```

### After
```js
// explicitly update index by add() or ignore() calls
const s = scaffe
    .generate(templateDir, outDir, { overwrite: true, variables: { name: "app" } })
    .add(src, target); // optional

if(type === "typescript"){
    s.ignore("**/*.js"); // remove files from index
    s.add(tsPath, outDir); // mutate as much as you can even conditionally
}

await s; // to execute
```

All paths mentioned by `add` or `ignore` should be relative to `templateDir`