### PR TITLE
Add 'dot' config option to support copying dot files and folders

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -9,6 +9,7 @@
  * @typedef {object} Configuration
  * @property {boolean} [overwrite=false] - will overwrite the target directory if true, by default false
  * @property {object} [variables = {}] - variables to be resolved in ejs template
+ * @property {boolean} [dot=false] - whether to copy dotfiles also or not
  */
 
 const fs = require("fs")
@@ -45,7 +46,7 @@ class Generator{
 
     fs.mkdirSync(this.outDir, options)
 
-    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true, dot: this.config.dot })
 
     for (const item of res){
       let dirname = path.dirname(item)
@@ -69,7 +70,7 @@ class Generator{
    * @param {string} outpath
    */
   walk(wpath, outpath){
-    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true, dot: this.config.dot })
     const outIsFile = outpath.endsWith(path.sep)
 
     for (const item of res){
@@ -86,7 +87,7 @@ class Generator{
    * @param {string} wpath
    */
   remove(wpath){
-    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true })
+    const res = glob.sync(wpath, { cwd: this.templateDir, onlyFiles: true, dot: this.config.dot })
     for (const item of res){
       delete this.fileMap[item]
     }

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -161,7 +161,7 @@ test("don't add file if ignored", async() => {
   expect(fs.existsSync("app/src/main.js")).toBe(false)
 })
 
-test("copy dot files if passed dot is passed in config", async() => {
+test("copy dot files if dot is passed true in config", async() => {
   expect.assertions(2)
 
   const s = generator("template", "app", {

--- a/lib/generator.test.js
+++ b/lib/generator.test.js
@@ -24,6 +24,8 @@ beforeEach(async() => {
         dist: {
           "index.html": "<html></html>",
         },
+        ".gitignore": "node_modules/",
+        ".git": { "index": "" }
       },
       "_package.json": `
         {
@@ -157,6 +159,43 @@ test("don't add file if ignored", async() => {
   await s
 
   expect(fs.existsSync("app/src/main.js")).toBe(false)
+})
+
+test("copy dot files if passed dot is passed in config", async() => {
+  expect.assertions(2)
+
+  const s = generator("template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+    dot: true
+  })
+
+  await s
+
+  expect(fs.existsSync("app/src/.gitignore")).toBe(true)
+  expect(fs.existsSync("app/src/.git")).toBe(true)
+})
+
+test("ignore dot files and folder", async() => {
+  expect.assertions(2)
+
+  const s = generator("template", "app", {
+    variables: {
+      name: "sinix",
+      version: "0.1.0",
+    },
+    dot: true
+  })
+
+  s.ignore("src/.git/**")
+  s.ignore("src/.gitignore")
+
+  await s
+
+  expect(fs.existsSync("app/src/.git")).toBe(false)
+  expect(fs.existsSync("app/src/.gitignore")).toBe(false)
 })
 
 test("copy file to a custom place", async() => {


### PR DESCRIPTION
Add a new property in config (2nd parameter) `dot` denoting "whether to copy dotfiles or not`